### PR TITLE
#3 increase size of lastipaddress to support ipv6

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -176,6 +176,7 @@ hr {
         <ul>
             <li>[<a href='https://issues.igniterealtime.org/browse/OF-1641'>OF-1641</a>] - Ensure all JSP pages have the correct contentType.</li>
             <li>[<a href='https://issues.igniterealtime.org/browse/OF-1517'>OF-1517</a>] - Don't require i18n source files for all plugins to be encoded.</li>
+            <li>[<a href='https://github.com/igniterealtime/openfire-userStatus-plugin/issues/3'>Issue #3</a> - Support IPv6 addresses</li>
             <li>Minimum Java requirement: 1.8</li>
         </ul>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -13,7 +13,7 @@
     <minServerVersion>4.0.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <databaseKey>user-status</databaseKey>
-    <databaseVersion>0</databaseVersion>
+    <databaseVersion>1</databaseVersion>
     <licenseType>gpl</licenseType>
     
     <!-- Admin console meta-data -->

--- a/readme.html
+++ b/readme.html
@@ -212,7 +212,7 @@ CREATE TABLE userStatus (
     resource        VARCHAR(64)         NOT NULL,
     online          TINYINT             NOT NULL,
     presence        CHAR(15),
-    lastIpAddress   CHAR(15)            NOT NULL,
+    lastIpAddress   CHAR(45)            NOT NULL,
     lastLoginDate   CHAR(15)            NOT NULL,
     lastLogoffDate  CHAR(15),
     PRIMARY KEY pk_userStatus (username, resource)
@@ -228,7 +228,7 @@ CREATE TABLE userStatusHistory (
     historyID       BIGINT              NOT NULL,
     username        VARCHAR(64)         NOT NULL,
     resource        VARCHAR(64)         NOT NULL,
-    lastIpAddress   CHAR(15)            NOT NULL,
+    lastIpAddress   CHAR(45)            NOT NULL,
     lastLoginDate   CHAR(15)            NOT NULL,
     lastLogoffDate  CHAR(15)            NOT NULL,
     PRIMARY KEY pk_userStatusHistory (historyID)

--- a/src/database/upgrade/1/user-status_db2.sql
+++ b/src/database/upgrade/1/user-status_db2.sql
@@ -1,0 +1,6 @@
+# expand lastIpAddress field to support IPv6 addresses
+alter table userStatus modify column lastIpAddress char(45);
+alter table userStatusHistory modify column lastIpAddress char(45);
+
+# update version
+UPDATE ofVersion SET version = 1 WHERE name = 'user-status';

--- a/src/database/upgrade/1/user-status_hsqldb.sql
+++ b/src/database/upgrade/1/user-status_hsqldb.sql
@@ -1,0 +1,6 @@
+# expand lastIpAddress field to support IPv6 addresses
+alter table userStatus modify column lastIpAddress char(45);
+alter table userStatusHistory modify column lastIpAddress char(45);
+
+# update version
+UPDATE ofVersion SET version = 1 WHERE name = 'user-status';

--- a/src/database/upgrade/1/user-status_hsqldb.sql
+++ b/src/database/upgrade/1/user-status_hsqldb.sql
@@ -1,6 +1,6 @@
 # expand lastIpAddress field to support IPv6 addresses
-alter table userStatus modify column lastIpAddress char(45);
-alter table userStatusHistory modify column lastIpAddress char(45);
+alter table userStatus modify column lastIpAddress VARCHAR(45);
+alter table userStatusHistory modify column lastIpAddress VARCHAR(45);
 
 # update version
 UPDATE ofVersion SET version = 1 WHERE name = 'user-status';

--- a/src/database/upgrade/1/user-status_mysql.sql
+++ b/src/database/upgrade/1/user-status_mysql.sql
@@ -1,0 +1,6 @@
+# expand lastIpAddress field to support IPv6 addresses
+alter table userStatus modify column lastIpAddress char(45);
+alter table userStatusHistory modify column lastIpAddress char(45);
+
+# update version
+UPDATE ofVersion SET version = 1 WHERE name = 'user-status';

--- a/src/database/upgrade/1/user-status_postgresql.sql
+++ b/src/database/upgrade/1/user-status_postgresql.sql
@@ -1,0 +1,6 @@
+# expand lastIpAddress field to support IPv6 addresses
+alter table userStatus modify column lastIpAddress char(45);
+alter table userStatusHistory modify column lastIpAddress char(45);
+
+# update version
+UPDATE ofVersion SET version = 1 WHERE name = 'user-status';

--- a/src/database/upgrade/1/user-status_postgresql.sql
+++ b/src/database/upgrade/1/user-status_postgresql.sql
@@ -1,6 +1,6 @@
 # expand lastIpAddress field to support IPv6 addresses
-alter table userStatus modify column lastIpAddress char(45);
-alter table userStatusHistory modify column lastIpAddress char(45);
+alter table userStatus alter column lastIpAddress type char(45);
+alter table userStatusHistory alter column lastIpAddress type char(45);;
 
 # update version
 UPDATE ofVersion SET version = 1 WHERE name = 'user-status';

--- a/src/database/upgrade/1/user-status_sqlserver.sql
+++ b/src/database/upgrade/1/user-status_sqlserver.sql
@@ -1,0 +1,6 @@
+# expand lastIpAddress field to support IPv6 addresses
+alter table userStatus modify column lastIpAddress char(45);
+alter table userStatusHistory modify column lastIpAddress char(45);
+
+# update version
+UPDATE ofVersion SET version = 1 WHERE name = 'user-status';

--- a/src/database/upgrade/1/user-status_sqlserver.sql
+++ b/src/database/upgrade/1/user-status_sqlserver.sql
@@ -1,6 +1,6 @@
 # expand lastIpAddress field to support IPv6 addresses
-alter table userStatus modify column lastIpAddress char(45);
-alter table userStatusHistory modify column lastIpAddress char(45);
+alter table userStatus modify column lastIpAddress NVARCHAR(45);
+alter table userStatusHistory modify column lastIpAddress NVARCHAR(45);
 
 # update version
 UPDATE ofVersion SET version = 1 WHERE name = 'user-status';

--- a/src/database/user-status_db2.sql
+++ b/src/database/user-status_db2.sql
@@ -2,7 +2,7 @@ CREATE TABLE userStatusHistory (
     historyID       BIGINT              NOT NULL,
     username        VARCHAR(64)         NOT NULL,
     resource        VARCHAR(64)         NOT NULL,
-    lastIpAddress   CHAR(40)            NOT NULL,
+    lastIpAddress   CHAR(45)            NOT NULL,
     lastLoginDate   CHAR(15)            NOT NULL,
     lastLogoffDate  CHAR(15)            NOT NULL,
     PRIMARY KEY(historyID)
@@ -13,7 +13,7 @@ CREATE TABLE userStatus (
     resource VARCHAR(64) NOT NULL,
     online INT NOT NULL,
     presence CHAR(15),
-    lastIpAddress CHAR(40) NOT NULL,
+    lastIpAddress CHAR(45) NOT NULL,
     lastLoginDate CHAR(15) NOT NULL,
     lastLogoffDate CHAR(15),
     PRIMARY KEY(username, resource)

--- a/src/database/user-status_db2.sql
+++ b/src/database/user-status_db2.sql
@@ -2,7 +2,7 @@ CREATE TABLE userStatusHistory (
     historyID       BIGINT              NOT NULL,
     username        VARCHAR(64)         NOT NULL,
     resource        VARCHAR(64)         NOT NULL,
-    lastIpAddress   CHAR(15)            NOT NULL,
+    lastIpAddress   CHAR(40)            NOT NULL,
     lastLoginDate   CHAR(15)            NOT NULL,
     lastLogoffDate  CHAR(15)            NOT NULL,
     PRIMARY KEY(historyID)
@@ -13,7 +13,7 @@ CREATE TABLE userStatus (
     resource VARCHAR(64) NOT NULL,
     online INT NOT NULL,
     presence CHAR(15),
-    lastIpAddress CHAR(15) NOT NULL,
+    lastIpAddress CHAR(40) NOT NULL,
     lastLoginDate CHAR(15) NOT NULL,
     lastLogoffDate CHAR(15),
     PRIMARY KEY(username, resource)

--- a/src/database/user-status_db2.sql
+++ b/src/database/user-status_db2.sql
@@ -19,4 +19,4 @@ CREATE TABLE userStatus (
     PRIMARY KEY(username, resource)
 );
 
-INSERT INTO ofVersion (name, version) VALUES ('user-status', 0);
+INSERT INTO ofVersion (name, version) VALUES ('user-status', 1);

--- a/src/database/user-status_hsqldb.sql
+++ b/src/database/user-status_hsqldb.sql
@@ -3,7 +3,7 @@ CREATE TABLE userStatus (
     resource        VARCHAR(64)         NOT NULL,
     online          INTEGER             NOT NULL,
     presence        VARCHAR(15),
-    lastIpAddress   VARCHAR(40)            NOT NULL,
+    lastIpAddress   VARCHAR(45)            NOT NULL,
     lastLoginDate   VARCHAR(15)            NOT NULL,
     lastLogoffDate  VARCHAR(15),
     PRIMARY KEY (username, resource)
@@ -13,7 +13,7 @@ CREATE TABLE userStatusHistory (
     historyID       BIGINT              NOT NULL,
     username        VARCHAR(64)         NOT NULL,
     resource        VARCHAR(64)         NOT NULL,
-    lastIpAddress   VARCHAR(40)            NOT NULL,
+    lastIpAddress   VARCHAR(45)            NOT NULL,
     lastLoginDate   VARCHAR(15)            NOT NULL,
     lastLogoffDate  VARCHAR(15)            NOT NULL,
     PRIMARY KEY (historyID)

--- a/src/database/user-status_hsqldb.sql
+++ b/src/database/user-status_hsqldb.sql
@@ -3,7 +3,7 @@ CREATE TABLE userStatus (
     resource        VARCHAR(64)         NOT NULL,
     online          INTEGER             NOT NULL,
     presence        VARCHAR(15),
-    lastIpAddress   VARCHAR(15)            NOT NULL,
+    lastIpAddress   VARCHAR(40)            NOT NULL,
     lastLoginDate   VARCHAR(15)            NOT NULL,
     lastLogoffDate  VARCHAR(15),
     PRIMARY KEY (username, resource)
@@ -13,7 +13,7 @@ CREATE TABLE userStatusHistory (
     historyID       BIGINT              NOT NULL,
     username        VARCHAR(64)         NOT NULL,
     resource        VARCHAR(64)         NOT NULL,
-    lastIpAddress   VARCHAR(15)            NOT NULL,
+    lastIpAddress   VARCHAR(40)            NOT NULL,
     lastLoginDate   VARCHAR(15)            NOT NULL,
     lastLogoffDate  VARCHAR(15)            NOT NULL,
     PRIMARY KEY (historyID)

--- a/src/database/user-status_hsqldb.sql
+++ b/src/database/user-status_hsqldb.sql
@@ -19,4 +19,4 @@ CREATE TABLE userStatusHistory (
     PRIMARY KEY (historyID)
 );
 
-INSERT INTO ofVersion (name, version) VALUES ('user-status', 0);
+INSERT INTO ofVersion (name, version) VALUES ('user-status', 1);

--- a/src/database/user-status_mysql.sql
+++ b/src/database/user-status_mysql.sql
@@ -19,4 +19,4 @@ CREATE TABLE userStatusHistory (
     PRIMARY KEY pk_userStatusHistory (historyID)
 );
 
-INSERT INTO ofVersion (name, version) VALUES ('user-status', 0);
+INSERT INTO ofVersion (name, version) VALUES ('user-status', 1);

--- a/src/database/user-status_mysql.sql
+++ b/src/database/user-status_mysql.sql
@@ -3,7 +3,7 @@ CREATE TABLE userStatus (
     resource        VARCHAR(64)         NOT NULL,
     online          TINYINT             NOT NULL,
     presence        CHAR(15),
-    lastIpAddress   CHAR(15)            NOT NULL,
+    lastIpAddress   CHAR(40)            NOT NULL,
     lastLoginDate   CHAR(15)            NOT NULL,
     lastLogoffDate  CHAR(15),
     PRIMARY KEY pk_userStatus (username, resource)
@@ -13,7 +13,7 @@ CREATE TABLE userStatusHistory (
     historyID       BIGINT              NOT NULL,
     username        VARCHAR(64)         NOT NULL,
     resource        VARCHAR(64)         NOT NULL,
-    lastIpAddress   CHAR(15)            NOT NULL,
+    lastIpAddress   CHAR(40)            NOT NULL,
     lastLoginDate   CHAR(15)            NOT NULL,
     lastLogoffDate  CHAR(15)            NOT NULL,
     PRIMARY KEY pk_userStatusHistory (historyID)

--- a/src/database/user-status_mysql.sql
+++ b/src/database/user-status_mysql.sql
@@ -3,7 +3,7 @@ CREATE TABLE userStatus (
     resource        VARCHAR(64)         NOT NULL,
     online          TINYINT             NOT NULL,
     presence        CHAR(15),
-    lastIpAddress   CHAR(40)            NOT NULL,
+    lastIpAddress   CHAR(45)            NOT NULL,
     lastLoginDate   CHAR(15)            NOT NULL,
     lastLogoffDate  CHAR(15),
     PRIMARY KEY pk_userStatus (username, resource)
@@ -13,7 +13,7 @@ CREATE TABLE userStatusHistory (
     historyID       BIGINT              NOT NULL,
     username        VARCHAR(64)         NOT NULL,
     resource        VARCHAR(64)         NOT NULL,
-    lastIpAddress   CHAR(40)            NOT NULL,
+    lastIpAddress   CHAR(45)            NOT NULL,
     lastLoginDate   CHAR(15)            NOT NULL,
     lastLogoffDate  CHAR(15)            NOT NULL,
     PRIMARY KEY pk_userStatusHistory (historyID)

--- a/src/database/user-status_postgresql.sql
+++ b/src/database/user-status_postgresql.sql
@@ -3,7 +3,7 @@ CREATE TABLE userStatus (
     resource VARCHAR(64) NOT NULL,
     online INTEGER NOT NULL,
     presence CHAR(15),
-    lastIpAddress CHAR(15) NOT NULL,
+    lastIpAddress CHAR(40) NOT NULL,
     lastLoginDate CHAR(15) NOT NULL,
     lastLogoffDate CHAR(15),
     constraint pk_userStatus PRIMARY KEY  (username, resource)
@@ -13,7 +13,7 @@ CREATE TABLE userStatusHistory (
     historyID BIGINT NOT NULL,
     username VARCHAR(64) NOT NULL,
     resource VARCHAR(64) NOT NULL,
-    lastIpAddress CHAR(15) NOT NULL,
+    lastIpAddress CHAR(40) NOT NULL,
     lastLoginDate CHAR(15) NOT NULL,
     lastLogoffDate CHAR(15) NOT NULL,
     constraint pk_userStatusHistory PRIMARY KEY (historyID)

--- a/src/database/user-status_postgresql.sql
+++ b/src/database/user-status_postgresql.sql
@@ -19,4 +19,4 @@ CREATE TABLE userStatusHistory (
     constraint pk_userStatusHistory PRIMARY KEY (historyID)
 );
 
-INSERT INTO ofVersion (name, version) VALUES ('user-status', 0);
+INSERT INTO ofVersion (name, version) VALUES ('user-status', 1);

--- a/src/database/user-status_postgresql.sql
+++ b/src/database/user-status_postgresql.sql
@@ -3,7 +3,7 @@ CREATE TABLE userStatus (
     resource VARCHAR(64) NOT NULL,
     online INTEGER NOT NULL,
     presence CHAR(15),
-    lastIpAddress CHAR(40) NOT NULL,
+    lastIpAddress CHAR(45) NOT NULL,
     lastLoginDate CHAR(15) NOT NULL,
     lastLogoffDate CHAR(15),
     constraint pk_userStatus PRIMARY KEY  (username, resource)
@@ -13,7 +13,7 @@ CREATE TABLE userStatusHistory (
     historyID BIGINT NOT NULL,
     username VARCHAR(64) NOT NULL,
     resource VARCHAR(64) NOT NULL,
-    lastIpAddress CHAR(40) NOT NULL,
+    lastIpAddress CHAR(45) NOT NULL,
     lastLoginDate CHAR(15) NOT NULL,
     lastLogoffDate CHAR(15) NOT NULL,
     constraint pk_userStatusHistory PRIMARY KEY (historyID)

--- a/src/database/user-status_sqlserver.sql
+++ b/src/database/user-status_sqlserver.sql
@@ -3,7 +3,7 @@ CREATE TABLE userStatus (
     resource        NVARCHAR(64)         NOT NULL,
     online          TINYINT             NOT NULL,
     presence        NVARCHAR(15),
-    lastIpAddress   NVARCHAR(15)            NOT NULL,
+    lastIpAddress   NVARCHAR(40)            NOT NULL,
     lastLoginDate   NVARCHAR(15)            NOT NULL,
     lastLogoffDate  NVARCHAR(15),
     CONSTRAINT userStatus_pk PRIMARY KEY (username, resource)
@@ -13,7 +13,7 @@ CREATE TABLE userStatusHistory (
     historyID       BIGINT              NOT NULL,
     username        NVARCHAR(64)         NOT NULL,
     resource        NVARCHAR(64)         NOT NULL,
-    lastIpAddress   NVARCHAR(15)            NOT NULL,
+    lastIpAddress   NVARCHAR(40)            NOT NULL,
     lastLoginDate   NVARCHAR(15)            NOT NULL,
     lastLogoffDate  NVARCHAR(15)            NOT NULL,
     CONSTRAINT userStatusHistory_pk PRIMARY KEY (historyID)

--- a/src/database/user-status_sqlserver.sql
+++ b/src/database/user-status_sqlserver.sql
@@ -3,7 +3,7 @@ CREATE TABLE userStatus (
     resource        NVARCHAR(64)         NOT NULL,
     online          TINYINT             NOT NULL,
     presence        NVARCHAR(15),
-    lastIpAddress   NVARCHAR(40)            NOT NULL,
+    lastIpAddress   NVARCHAR(45)            NOT NULL,
     lastLoginDate   NVARCHAR(15)            NOT NULL,
     lastLogoffDate  NVARCHAR(15),
     CONSTRAINT userStatus_pk PRIMARY KEY (username, resource)
@@ -13,7 +13,7 @@ CREATE TABLE userStatusHistory (
     historyID       BIGINT              NOT NULL,
     username        NVARCHAR(64)         NOT NULL,
     resource        NVARCHAR(64)         NOT NULL,
-    lastIpAddress   NVARCHAR(40)            NOT NULL,
+    lastIpAddress   NVARCHAR(45)            NOT NULL,
     lastLoginDate   NVARCHAR(15)            NOT NULL,
     lastLogoffDate  NVARCHAR(15)            NOT NULL,
     CONSTRAINT userStatusHistory_pk PRIMARY KEY (historyID)

--- a/src/database/user-status_sqlserver.sql
+++ b/src/database/user-status_sqlserver.sql
@@ -19,4 +19,4 @@ CREATE TABLE userStatusHistory (
     CONSTRAINT userStatusHistory_pk PRIMARY KEY (historyID)
 );
 
-INSERT INTO ofVersion (name, version) VALUES ('user-status', 0);
+INSERT INTO ofVersion (name, version) VALUES ('user-status', 1);


### PR DESCRIPTION
To fix https://github.com/igniterealtime/openfire-userStatus-plugin/issues/3

I have searched about supported size of char, varchar for various databases. It seems that they should all support (40), but maybe i missed something. This will only fix new installations of plugin. But current installations are probably all right, if they already work. Unless IPv6 addresses are introduced later. But then they can just alter their tables as the author of ticket did.

This commit is only for review. Changelog and other changes could be added with next commits.